### PR TITLE
Upgrading to actions/setup-go@v2 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,11 @@ jobs:
       uses: actions/setup-go@v2-beta
       with:
         go-version: 1.14.x
+    - name: Set Env
+      run: echo "name=GOROOT::/opt/hostedtoolcache/go/1.14.13/x64" >> $GITHUB_ENV
+           echo "/opt/hostedtoolcache/go/1.14.13/x64/bin" >> $GITHUB_PATH
+           echo "/home/runner/go/bin" >> $GITHUB_PATH
+
 
     - name: Start KinD Cluster
 #     Start a KinD K8s cluster with single worker node

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,11 +57,9 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
 
     - name: Set up Go
-      uses: actions/setup-go@v2-beta
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.14.x
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+        go-version: 1.14.13
 
     - name: Start KinD Cluster
 #     Start a KinD K8s cluster with single worker node

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,7 +59,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.14.13
+        go-version: 1.14.x
 
     - name: Start KinD Cluster
 #     Start a KinD K8s cluster with single worker node

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,11 +60,8 @@ jobs:
       uses: actions/setup-go@v2-beta
       with:
         go-version: 1.14.x
-    - name: Set Env
-      run: echo "name=GOROOT::/opt/hostedtoolcache/go/1.14.13/x64" >> $GITHUB_ENV
-           echo "/opt/hostedtoolcache/go/1.14.13/x64/bin" >> $GITHUB_PATH
-           echo "/home/runner/go/bin" >> $GITHUB_PATH
-
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
 
     - name: Start KinD Cluster
 #     Start a KinD K8s cluster with single worker node

--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -64,7 +64,7 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
 
     - name: Set up Go
-      uses: actions/setup-go@v2-beta
+      uses: actions/setup-go@v2
       with:
         go-version: 1.14.x
 

--- a/.github/workflows/k8s-matrix.yaml
+++ b/.github/workflows/k8s-matrix.yaml
@@ -68,7 +68,7 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
 
     - name: Set up Go
-      uses: actions/setup-go@v2-beta
+      uses: actions/setup-go@v2
       with:
         go-version: 1.14.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
 
     - name: Set up Go
-      uses: actions/setup-go@v2-beta
+      uses: actions/setup-go@v2
       with:
         go-version: 1.14.x
 


### PR DESCRIPTION
Done to fix the following errors in running the actions:

Error: Unable to process command '::set-env name=GOROOT::/opt/hostedtoolcache/go/1.14.13/x64' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '::add-path::/opt/hostedtoolcache/go/1.14.13/x64/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Added go to the path
Error: Unable to process command '::add-path::/home/runner/go/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
go version go1.14.13 linux/amd64