### PR TITLE
Changed the location to pick stable prometheus version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1107,7 +1107,7 @@ kind-load:
 install-prometheus:
 	kubectl create ns $(OPERATOR_NAMESPACE) || true
 	kubectl create -f hack/prometheus-rbac.yaml
-	helm repo add stable https://kubernetes-charts.storage.googleapis.com/ || true
+	helm repo add stable https://charts.helm.sh/stable || true
 	@echo "Create Grafana Dashboards ConfigMap:"
 	kubectl -n $(OPERATOR_NAMESPACE) create configmap coherence-grafana-dashboards --from-file=$(GRAFANA_DASHBOARDS)
 	kubectl -n $(OPERATOR_NAMESPACE) label configmap coherence-grafana-dashboards grafana_dashboard=1


### PR DESCRIPTION
Fix for the following error in the build:

clusterrolebinding.rbac.authorization.k8s.io/prometheus created
helm repo add stable https://kubernetes-charts.storage.googleapis.com/ || true
Error: repo "https://kubernetes-charts.storage.googleapis.com/" is no longer available; try "https://charts.helm.sh/stable" instead
Create Grafana Dashboards ConfigMap:
kubectl -n operator-test create configmap coherence-grafana-dashboards --from-file=dashboards/grafana-legacy/
configmap/coherence-grafana-dashboards created
kubectl -n operator-test label configmap coherence-grafana-dashboards grafana_dashboard=1
configmap/coherence-grafana-dashboards labeled
Getting Helm Version:
helm version
version.BuildInfo{Version:"v3.4.2", GitCommit:"23dd3af5e19a02d4f4baa5b2f242645a1a3af629", GitTreeState:"clean", GoVersion:"go1.14.13"}
Installing stable/prometheus-operator:
helm install --atomic --namespace operator-test --version 8.13.7 --wait \
	--set grafana.enabled=true \
	--values hack/prometheus-values.yaml prometheus stable/prometheus-operator
Error: failed to download "stable/prometheus-operator" at version "8.13.7" (hint: running `helm repo update` may help)
Makefile:1108: recipe for target 'install-prometheus' failed
make: *** [install-prometheus] Error 1